### PR TITLE
Modify regex for extracting strings to allow for parentheses

### DIFF
--- a/gen_dict.py
+++ b/gen_dict.py
@@ -23,7 +23,7 @@ def hash_djb2(string):
 def gen_loc_dict(code_dir):
     fileglob_list = []
     loc_dict = {}
-    pbllog_regex = "_\(\"(?P<loc>[^\)]+)\"\)"
+    pbllog_regex = "_\(\"(?P<loc>(?!\"\)).+)\"\)"
 
     for root, dirnames, filenames in os.walk(code_dir):
         for filename in [filename for filename in filenames \


### PR DESCRIPTION
Fixes #2 by modifying the string extraction regex to allow for parentheses inside the string.
