### PR TITLE
Fixed a memory leak while reading cstring data.

### DIFF
--- a/src/localize.c
+++ b/src/localize.c
@@ -44,20 +44,17 @@ void locale_init(void) {
   dict_write_begin(&s_locale_dict, (uint8_t*)dict_buffer, dict_buffer_size);
 
   for (int i = 0; i < locale_entries; i++) {
-    resource_offset += resource_load_byte_range(locale_handle, resource_offset, 
-        (uint8_t*)&locale_info, sizeof(struct locale));
-
-    struct Tuplet tupl = {
-      .type = TUPLE_CSTRING, 
-      .key = locale_info.hashval, 
-      .cstring.length = locale_info.strlen};
-
-    tupl.cstring.data = malloc(tupl.cstring.length);
-
-    resource_offset += resource_load_byte_range(locale_handle, 
-        resource_offset, (uint8_t*)tupl.cstring.data, tupl.cstring.length);
-
-    dict_write_tuplet(&s_locale_dict, &tupl);
+    resource_offset += resource_load_byte_range(locale_handle,
+                                                resource_offset,
+                                                (uint8_t*)&locale_info,
+                                                sizeof(struct locale));
+    char *buffer = malloc(locale_info.strlen);
+    resource_offset += resource_load_byte_range(locale_handle,
+                                                resource_offset,
+                                                (uint8_t*)buffer,
+                                                locale_info.strlen);
+    dict_write_cstring(&s_locale_dict, locale_info.hashval, buffer);
+    free(buffer);
   }
 
   dict_write_end(&s_locale_dict);


### PR DESCRIPTION
There was a critical memory leak in the locale_init() method. If we call locale_init() to toggle languages too often, the app will crash definitely, especially on Aplite.
Now it's fixed, every time we quit an app, the Heap Usage report will always say "Still allocated <0B>".
Yes, zero byte! No memory leak any more!